### PR TITLE
`ChildWhich` & `ChildWhichRef`

### DIFF
--- a/src/ChildWhich.lua
+++ b/src/ChildWhich.lua
@@ -1,0 +1,36 @@
+local Fusion = require(script.Parent.Parent.Fusion)
+
+local Value = Fusion.Value
+local Hydrate = Fusion.Hydrate
+
+local ChildWhichRef = require(script.Parent.ChildRef)
+local Observe = require(script.Parent.Observe)
+
+local ChildWhich = {
+	type = "SpecialKey";
+	kind = "ChildWhich";
+	stage = "descendants";
+
+	apply = function(self, value, applyTo, cleanupTasks)
+		local childRef = Value()
+		Hydrate(applyTo) {
+			[ChildWhichRef(self.condition)] = childRef
+		}
+
+		local isHydrated = {}
+		local result = Observe(childRef, function(child)
+			if isHydrated[child] then return end
+			isHydrated[child] = Hydrate(child)(value)
+		end, Fusion.doNothing)
+
+		table.insert(cleanupTasks, result)
+		table.insert(cleanupTasks, function()
+			childRef = nil
+		end)
+	end;
+}
+ChildWhich.__index = ChildWhich
+
+return function(condition: (Instance) -> boolean)
+	return setmetatable({ condition = condition; }, ChildWhich)
+end

--- a/src/ChildWhich.lua
+++ b/src/ChildWhich.lua
@@ -2,6 +2,7 @@ local Fusion = require(script.Parent.Parent.Fusion)
 
 local Value = Fusion.Value
 local Hydrate = Fusion.Hydrate
+local Cleanup = Fusion.Cleanup
 
 local ChildWhichRef = require(script.Parent.ChildRef)
 local Observe = require(script.Parent.Observe)
@@ -19,8 +20,19 @@ local ChildWhich = {
 
 		local isHydrated = {}
 		local result = Observe(childRef, function(child)
+			if not child then return end
 			if isHydrated[child] then return end
 			isHydrated[child] = Hydrate(child)(value)
+
+			-- Bind to child
+			Hydrate(child)(value)
+
+			-- Bind to cleanup of child
+			Hydrate(child) {
+				[Cleanup] = function()
+					isHydrated[child] = nil
+				end;
+			}
 		end, Fusion.doNothing)
 
 		table.insert(cleanupTasks, result)

--- a/src/ChildWhichRef.lua
+++ b/src/ChildWhichRef.lua
@@ -1,0 +1,29 @@
+local ChildWhichRef = {
+	type = "SpecialKey";
+	kind = "ChildWhichRef";
+	stage = "descendants";
+
+	apply = function(self, value, applyTo, cleanupTasks)
+		local condition = self.condition
+
+		if not applyTo then return end
+
+		for _, child in ipairs(applyTo:GetChildren()) do
+			if condition(child) then
+				value:set(child)
+				break
+			end
+		end
+
+		table.insert(cleanupTasks, applyTo.ChildAdded:Connect(function(newChild)
+			if condition(newChild) then
+				value:set(newChild)
+			end
+		end))
+	end;
+}
+ChildWhichRef.__index = ChildWhichRef
+
+return function(condition: (Instance) -> boolean)
+	return setmetatable({ condition = condition; }, ChildWhichRef)
+end

--- a/src/Conditions/Instances/init.lua
+++ b/src/Conditions/Instances/init.lua
@@ -1,0 +1,15 @@
+local Instances = {}
+
+function Instances.IsA(class: string)
+	return function(instance: Instance)
+		return instance:IsA(class)
+	end
+end
+
+function Instances.IsClass(class: string)
+	return function(instance: Instance)
+		return instance.ClassName == class
+	end
+end
+
+return Instances

--- a/src/Conditions/init.lua
+++ b/src/Conditions/init.lua
@@ -1,0 +1,3 @@
+return {
+	Instances = require(script.Instances);
+}

--- a/src/init.lua
+++ b/src/init.lua
@@ -13,4 +13,6 @@ return {
 	WithItems = require(script.WithItems);
 	Without = require(script.Without);
 	Bound = require(script.Bound);
+
+	Conditions = require(script.Conditions);
 }

--- a/src/init.lua
+++ b/src/init.lua
@@ -4,6 +4,7 @@ return {
 	ChildRef = require(script.ChildRef);
 	Child = require(script.Child);
 	ChildWhichRef = require(script.ChildWhichRef);
+	ChildWhich = require(script.ChildWhich);
 	Defer = require(script.Defer);
 	Observe = require(script.Observe);
 	ObserveSignal = require(script.ObserveSignal);

--- a/src/init.lua
+++ b/src/init.lua
@@ -3,6 +3,7 @@ return {
 	AttributeOut = require(script.AttributeOut);
 	ChildRef = require(script.ChildRef);
 	Child = require(script.Child);
+	ChildWhichRef = require(script.ChildWhichRef);
 	Defer = require(script.Defer);
 	Observe = require(script.Observe);
 	ObserveSignal = require(script.ObserveSignal);


### PR DESCRIPTION
Adds `ChildWhich` and `ChildWhichRef` which select a child based on an arbitrary condition function instead of by name.

Usage:
```lua
local humanoid = Value()
local health = Value(50)
local maxHealth = Value(100)

Hydrate(character) {
	[ChildWhichRef(function(child)
		return child:IsA("Humanoid")
	end)] = humanoid;

	[ChildWhich(function(child)
		return child:IsA("Humanoid")
	end)] = {
		Health = health;
		MaxHealth = maxHealth;
	};
}
```