### PR TITLE
Add `SharedProperty`

### DIFF
--- a/src/SharedProperty.lua
+++ b/src/SharedProperty.lua
@@ -1,0 +1,73 @@
+local RunService = game:GetService("RunService")
+local Fusion = require(script.Parent.Parent.Fusion)
+
+local Value = Fusion.Value
+local Ref = Fusion.Ref
+local Hydrate = Fusion.Hydrate
+local New = Fusion.New
+local OnEvent = Fusion.OnEvent
+local Children = Fusion.Children
+
+local Child = require(script.Parent.Child)
+local Observe = require(script.Parent.Observe)
+
+local REMOTE_CONTAINER_NAME = "_SharedProperties"
+
+local SharedProperty = {
+	type = "SpecialKey";
+	kind = "SharedProperty";
+	stage = "descendants";
+
+	apply = function<T>(self, value: Fusion.Value<T>, applyTo, cleanupTasks)
+		local name = self.name
+
+		local remoteRef = Value()
+		if RunService:IsServer() then
+			Hydrate(applyTo) {
+				[Child(REMOTE_CONTAINER_NAME)] = {
+					[Children] = New "RemoteEvent" {
+						[Ref] = remoteRef;
+
+						Name = name;
+						[OnEvent "OnServerEvent"] = function(player: Player)
+							local remote = remoteRef:get()
+							if not remote then return end
+							remote:FireClient(player, value:get())
+						end;
+					}
+				};
+	
+				[Children] = if not applyTo:FindFirstChild(REMOTE_CONTAINER_NAME) then New "Folder" {
+					Name = REMOTE_CONTAINER_NAME;
+				} else nil
+			}
+
+			table.insert(cleanupTasks, Observe(value, function(newValue)
+				local remote = remoteRef:get()
+				remote:FireAllClients(newValue)
+			end))
+		else
+			Hydrate(applyTo) {
+				[Child(REMOTE_CONTAINER_NAME)] = {
+					[Ref] = remoteRef;
+
+					[Child(name)] = {
+						[OnEvent "OnClientEvent"] = function(newValue: any)
+							value:set(newValue)
+						end;
+					}
+				}
+			}
+
+			table.insert(cleanupTasks, Observe(remoteRef, function(remote)
+				if not remote then return end
+				remote:FireServer()
+			end))
+		end
+	end
+}
+SharedProperty.__index = SharedProperty
+
+return function(name: string)
+	return setmetatable({ name = name; }, SharedProperty)
+end

--- a/src/init.lua
+++ b/src/init.lua
@@ -10,5 +10,6 @@ return {
 	With = require(script.With);
 	WithItems = require(script.WithItems);
 	Without = require(script.Without);
+	SharedProperty = require(script.SharedProperty);
 	Bound = require(script.Bound);
 }


### PR DESCRIPTION
Adds a special key called `ShareProperty` which syncs a Fusion Value to clients using a descendant `RemoteEvent`.
Events are stored in a `Folder` titled `_SharedProperties`.

Usage:
```lua
-- Server
local abc = Value(123)
New "Folder" {
	[SharedProperty "Abc"] = abc
}

-- Client
local abc = Value()
Hydrate(folder) {
	[SharedProperty "Abc"] = abc
}
Observe(abc, print) -- nil, then 123
```